### PR TITLE
Improve README formatting and clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,15 @@
 # nba-sim
 
-For now it's:
+A project for NBA simulation and analysis.
 
-1. process_text.py
-2. train_model.py
-3. token_exploration.ipynb
+## Project Structure
 
-I'm using weights and biases to track progress and you'll probably need to create an account their to run it easily.
+The project currently consists of the following main components:
+
+1. [`process_text.py`](./process_text.py) - Text processing utilities
+2. [`train_model.py`](./train_model.py) - Model training script
+3. [`token_exploration.ipynb`](./token_exploration.ipynb) - Jupyter notebook for token analysis
+
+## Setup
+
+This project uses [Weights & Biases](https://wandb.ai/) for experiment tracking. You'll need to create an account there to run the project easily.


### PR DESCRIPTION
This PR improves the README by:

- Adding a brief project description
- Adding proper section headings
- Converting file references to clickable links
- Adding descriptions for each component
- Fixing typos
- Adding a link to Weights & Biases website
- Making the wording more professional and informative